### PR TITLE
EMAConfig metadata Error

### DIFF
--- a/fairseq/dataclass/configs.py
+++ b/fairseq/dataclass/configs.py
@@ -1100,7 +1100,7 @@ class InteractiveConfig(FairseqDataclass):
 @dataclass
 class EMAConfig(FairseqDataclass):
     store_ema: bool = field(
-        default=False, metadata={help: "store exponential moving average shadow model"}
+        default=False, metadata={"help": "store exponential moving average shadow model"}
     )
     ema_decay: float = field(
         default=0.9999, metadata={"help": "decay for exponential moving average model"}


### PR DESCRIPTION
default=False, metadata={help: "store exponential moving average shadow model"}

default=False, metadata={"help": "store exponential moving average shadow model"}

 double quotes around the key


It's This Issue : https://github.com/facebookresearch/fairseq/issues/4659